### PR TITLE
Update types.ts

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -221,12 +221,14 @@ export interface FundingRate {
   }
 
 export interface PositionRisk {
+    breakEvenPrice: string
     entryPrice: string
     marginType: 'isolated' | 'cross'
     isAutoAddMargin: string
     isolatedMargin: string
     leverage: string
     liquidationPrice: string
+    marginAsset: string
     markPrice: string
     maxNotionalValue: string
     positionAmt: string


### PR DESCRIPTION
Some key items are missing from `PositionRisk` for the Futures when calling `futuresPositionRisk`. I need in particular `breakEvenPrice` for sure, and maybe `marginAsset` later.

 * Adding `breakEvenPrice` and `marginAsset` to `PositionRisk`.