### PR TITLE
Fix for tradeFee

### DIFF
--- a/src/node-binance-api.ts
+++ b/src/node-binance-api.ts
@@ -3685,7 +3685,7 @@ export default class Binance {
     */
     async tradeFee(symbol?: string) {
         const params = symbol ? { symbol: symbol } : {};
-        return await this.privateSpotRequest('v1/asset/tradeFee', params);
+        return await this.privateSapiRequest('v1/asset/tradeFee', params);
     }
 
     /**


### PR DESCRIPTION
According to https://developers.binance.com/docs/wallet/asset/trade-fee this should use `/sapi/v1/asset/tradeFee` instead of `/api/v1/asset/tradeFee`